### PR TITLE
Bugfix

### DIFF
--- a/get-bip39.py
+++ b/get-bip39.py
@@ -23,7 +23,7 @@ print("Use this tool at your own risk. Abandon all hope ye who enter here. Etc."
 print("------------------------------------------------------------------------\n\n")
 
 preimg = (long_random_string + serial_number).encode('utf-8')
-print("Input = " + preimg)
+print(f"Input = {preimg}")
 
 entropy = hashlib.sha256(preimg).hexdigest()
 print ("Input Hash = " + entropy)


### PR DESCRIPTION
the original doesn't work, it throws this error:

Traceback (most recent call last):
  File "get-bip39.py", line 26, in <module>
    print("Input = " + preimg)
TypeError: can only concatenate str (not "bytes") to str

changing line 26 to an f-string fixed it

tested on Linux with Python 3.8.10